### PR TITLE
[Feat]#4-detail-Re-파일 새로 생성 및 브랜치 다시 생성

### DIFF
--- a/PopDangSquare.xcodeproj/project.pbxproj
+++ b/PopDangSquare.xcodeproj/project.pbxproj
@@ -18,6 +18,16 @@
 		85AC10452BD749B000C00DCF /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AC10442BD749B000C00DCF /* LoginViewController.swift */; };
 		85AC10482BD7846F00C00DCF /* TextFieldExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AC10472BD7846F00C00DCF /* TextFieldExtension.swift */; };
 		85AC104A2BD7971300C00DCF /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AC10492BD7971300C00DCF /* SignUpViewController.swift */; };
+		CCD2A2592BD9F5AF0001FEC4 /* DetailView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CCD2A2532BD9F5AF0001FEC4 /* DetailView.storyboard */; };
+		CCD2A25A2BD9F5AF0001FEC4 /* DetailViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CCD2A2542BD9F5AF0001FEC4 /* DetailViewCell.xib */; };
+		CCD2A25B2BD9F5AF0001FEC4 /* DetailReviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2A2552BD9F5AF0001FEC4 /* DetailReviewCell.swift */; };
+		CCD2A25C2BD9F5AF0001FEC4 /* DetailViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2A2562BD9F5AF0001FEC4 /* DetailViewCell.swift */; };
+		CCD2A25D2BD9F5AF0001FEC4 /* DetailHeaderReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2A2572BD9F5AF0001FEC4 /* DetailHeaderReusableView.swift */; };
+		CCD2A25E2BD9F5AF0001FEC4 /* DetailReviewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CCD2A2582BD9F5AF0001FEC4 /* DetailReviewCell.xib */; };
+		CCD2A2602BD9F5CC0001FEC4 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2A25F2BD9F5CC0001FEC4 /* DetailViewController.swift */; };
+		CCD2A2642BD9F5DA0001FEC4 /* DetailData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2A2612BD9F5DA0001FEC4 /* DetailData.swift */; };
+		CCD2A2652BD9F5DA0001FEC4 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2A2622BD9F5DA0001FEC4 /* NetworkManager.swift */; };
+		CCD2A2662BD9F5DA0001FEC4 /* ReviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2A2632BD9F5DA0001FEC4 /* ReviewData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +44,16 @@
 		85AC10442BD749B000C00DCF /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		85AC10472BD7846F00C00DCF /* TextFieldExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldExtension.swift; sourceTree = "<group>"; };
 		85AC10492BD7971300C00DCF /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
+		CCD2A2532BD9F5AF0001FEC4 /* DetailView.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = DetailView.storyboard; sourceTree = "<group>"; };
+		CCD2A2542BD9F5AF0001FEC4 /* DetailViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DetailViewCell.xib; sourceTree = "<group>"; };
+		CCD2A2552BD9F5AF0001FEC4 /* DetailReviewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailReviewCell.swift; sourceTree = "<group>"; };
+		CCD2A2562BD9F5AF0001FEC4 /* DetailViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailViewCell.swift; sourceTree = "<group>"; };
+		CCD2A2572BD9F5AF0001FEC4 /* DetailHeaderReusableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailHeaderReusableView.swift; sourceTree = "<group>"; };
+		CCD2A2582BD9F5AF0001FEC4 /* DetailReviewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DetailReviewCell.xib; sourceTree = "<group>"; };
+		CCD2A25F2BD9F5CC0001FEC4 /* DetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
+		CCD2A2612BD9F5DA0001FEC4 /* DetailData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailData.swift; sourceTree = "<group>"; };
+		CCD2A2622BD9F5DA0001FEC4 /* NetworkManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		CCD2A2632BD9F5DA0001FEC4 /* ReviewData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +101,9 @@
 		85AC103F2BD658FC00C00DCF /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				CCD2A2612BD9F5DA0001FEC4 /* DetailData.swift */,
+				CCD2A2622BD9F5DA0001FEC4 /* NetworkManager.swift */,
+				CCD2A2632BD9F5DA0001FEC4 /* ReviewData.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -89,6 +112,7 @@
 			isa = PBXGroup;
 			children = (
 				85AC102F2BD64CAF00C00DCF /* ViewController.swift */,
+				CCD2A25F2BD9F5CC0001FEC4 /* DetailViewController.swift */,
 				85AC10442BD749B000C00DCF /* LoginViewController.swift */,
 				85AC10492BD7971300C00DCF /* SignUpViewController.swift */,
 			);
@@ -100,6 +124,12 @@
 			children = (
 				85AC10312BD64CAF00C00DCF /* Main.storyboard */,
 				85AC10362BD64CB100C00DCF /* LaunchScreen.storyboard */,
+				CCD2A2572BD9F5AF0001FEC4 /* DetailHeaderReusableView.swift */,
+				CCD2A2552BD9F5AF0001FEC4 /* DetailReviewCell.swift */,
+				CCD2A2582BD9F5AF0001FEC4 /* DetailReviewCell.xib */,
+				CCD2A2532BD9F5AF0001FEC4 /* DetailView.storyboard */,
+				CCD2A2562BD9F5AF0001FEC4 /* DetailViewCell.swift */,
+				CCD2A2542BD9F5AF0001FEC4 /* DetailViewCell.xib */,
 				85AC10422BD680E000C00DCF /* LoginView.storyboard */,
 			);
 			path = View;
@@ -175,6 +205,9 @@
 				85AC10352BD64CB100C00DCF /* Assets.xcassets in Resources */,
 				85AC10382BD64CB100C00DCF /* Base in Resources */,
 				85AC10332BD64CAF00C00DCF /* Base in Resources */,
+				CCD2A25E2BD9F5AF0001FEC4 /* DetailReviewCell.xib in Resources */,
+				CCD2A25A2BD9F5AF0001FEC4 /* DetailViewCell.xib in Resources */,
+				CCD2A2592BD9F5AF0001FEC4 /* DetailView.storyboard in Resources */,
 				85AC10432BD680E000C00DCF /* LoginView.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -186,13 +219,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CCD2A2602BD9F5CC0001FEC4 /* DetailViewController.swift in Sources */,
 				85AC104A2BD7971300C00DCF /* SignUpViewController.swift in Sources */,
 				85AC10452BD749B000C00DCF /* LoginViewController.swift in Sources */,
+				CCD2A2652BD9F5DA0001FEC4 /* NetworkManager.swift in Sources */,
 				854B8DA42BD8A1F1003AB9AC /* UIResponderExtension.swift in Sources */,
+				CCD2A2662BD9F5DA0001FEC4 /* ReviewData.swift in Sources */,
 				85AC10302BD64CAF00C00DCF /* ViewController.swift in Sources */,
 				85AC102C2BD64CAF00C00DCF /* AppDelegate.swift in Sources */,
 				85AC10482BD7846F00C00DCF /* TextFieldExtension.swift in Sources */,
+				CCD2A25C2BD9F5AF0001FEC4 /* DetailViewCell.swift in Sources */,
+				CCD2A2642BD9F5DA0001FEC4 /* DetailData.swift in Sources */,
+				CCD2A25B2BD9F5AF0001FEC4 /* DetailReviewCell.swift in Sources */,
 				85AC102E2BD64CAF00C00DCF /* SceneDelegate.swift in Sources */,
+				CCD2A25D2BD9F5AF0001FEC4 /* DetailHeaderReusableView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PopDangSquare/Controller/DetailViewController.swift
+++ b/PopDangSquare/Controller/DetailViewController.swift
@@ -1,0 +1,103 @@
+//
+//  DetailViewController.swift
+//  PopDangSquare
+//
+//  Created by 민웅킴 on 4/22/24.
+//
+
+import UIKit
+
+class DetailViewController: UIViewController {
+    
+    @IBOutlet weak var detailCollView: UICollectionView!
+    
+    enum SectionType: Int, CaseIterable {
+        case detail, review
+        
+        var columnCount: Int {
+            switch self {
+            case .detail:
+                return DetailData.detail.count
+            case .review:
+                return ReviewData.reviews.count
+            }
+        }
+        enum ItemType: Hashable{
+            case detail(DetailData)
+            case review(ReviewData)
+        }
+    }
+    
+    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+    
+    var datasource: UICollectionViewDiffableDataSource<SectionType, SectionType.ItemType>!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupCollectionView()
+        setupDataSource()
+        NetworkManager.fetchMovies { _, _ in
+            
+        }
+        
+        // Apply initial snapshot
+        var snapshot = NSDiffableDataSourceSnapshot<SectionType, SectionType.ItemType>()
+        snapshot.appendSections([.detail, .review])
+        snapshot.appendItems([.detail(DetailData.init(movieNm: "범죄도시7", movieNmEn: "BeomjoeCity", prdtYear: "2024.05.05"))], toSection: .detail)
+        snapshot.appendItems([.review(ReviewData.init(detailStars: "⭐️⭐️⭐️⭐️", detailDate: "220108", detailReview: "내가 살면서 이런 영화 다시 보나 봐라. 진짜로. 근데 재밌음.. 사실 재미있었다. 나만 보고싶어서 평점 이렇게 남겨봅니다. 하하호호 제작진들 놀랬겠죠? 후핫"))], toSection: .review)
+        datasource.apply(snapshot)
+        //Layout
+        detailCollView.collectionViewLayout = layout()
+    }
+    
+    private func setupCollectionView() {
+        detailCollView.register(UINib(nibName: "DetailViewCell", bundle: nil), forCellWithReuseIdentifier: "DetailViewCell")
+        detailCollView.register(UINib(nibName: "DetailReviewCell", bundle: nil), forCellWithReuseIdentifier: "DetailReviewCell")
+        detailCollView.dataSource = datasource
+    }
+    
+    private func setupDataSource() {
+        datasource = UICollectionViewDiffableDataSource<SectionType, SectionType.ItemType>(collectionView: detailCollView, cellProvider: {
+            collectionView, indexPath, item in
+            
+            switch self.datasource.snapshot().sectionIdentifiers[indexPath.section] {
+                
+            case .detail:
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "DetailViewCell", for: indexPath) as? DetailViewCell,
+                      case let .detail(detailItem) = item
+                else {
+                    return DetailViewCell()
+                }
+                cell.configure(detailItem)
+                return cell
+                
+            case .review:
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "DetailReviewCell", for: indexPath) as? DetailReviewCell,
+                      case let .review(reviewItem) = item
+                else {
+                    return DetailReviewCell()
+                }
+                cell.configure(reviewItem)
+                return cell
+            }
+        })
+    }
+    
+    private func layout() -> UICollectionViewCompositionalLayout {
+        
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(0.8))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(0.5))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 30, leading: 20, bottom: 30, trailing: 20)
+        section.interGroupSpacing = 20
+        let layout = UICollectionViewCompositionalLayout(section: section)
+        return layout
+    }
+    
+}
+

--- a/PopDangSquare/Model/DetailData.swift
+++ b/PopDangSquare/Model/DetailData.swift
@@ -1,0 +1,23 @@
+//
+//  DetailReviewData.swift
+//  PopDangSquare
+//
+//  Created by 민웅킴 on 4/22/24.
+//
+
+import Foundation
+
+struct DetailData: Hashable {
+    let movieNm: String
+    let movieNmEn: String
+    let prdtYear: String
+}
+
+extension DetailData {
+    static let detail: [DetailData] = [
+        DetailData(movieNm: "무궁화꽃이", movieNmEn: "eqweqwqwe", prdtYear: "11.11.11"),
+        DetailData(movieNm: "피었습니다", movieNmEn: "dsfhdf", prdtYear: "22.22.22"),
+        DetailData(movieNm: "무궁화꽃2", movieNmEn: "qwehkashdk", prdtYear: "33.33.33"),
+        DetailData(movieNm: "피엇읍닏아", movieNmEn: "qewkj", prdtYear: "44.44.44")
+    ]
+}

--- a/PopDangSquare/Model/NetworkManager.swift
+++ b/PopDangSquare/Model/NetworkManager.swift
@@ -1,0 +1,43 @@
+//
+//  NetworkManager.swift
+//  PopDangSquare
+//
+//  Created by 민웅킴 on 4/24/24.
+//
+
+import Foundation
+
+struct Movie: Codable {
+    let movieNm: String
+    let movieNmEn: String
+}
+
+class NetworkManager {
+    
+    static let apiUrl = URL(string: "https://www.kobis.or.kr/kobisopenapi/webservice/rest/movie/searchMovieInfo.json?key=9a51098fee3a5f3ee0d7e6cb17074a8c&movieCd=20200202")!
+    
+    static func fetchMovies(completion: @escaping ([Movie]?, Error?) -> Void) {
+        let task = URLSession.shared.dataTask(with: apiUrl) { (data, response, error) in
+            if let error = error {
+                print(error)
+                completion(nil, error)
+                return
+            }
+            
+            guard let data = data else {
+                completion(nil, NSError(domain: "NoData", code: 1, userInfo: nil))
+                return
+            }
+            
+            do {
+                let movies = try JSONDecoder().decode([Movie].self, from: data)
+                completion(movies, nil)
+                print(movies)
+            } catch {
+                print(error)
+                completion(nil, error)
+            }
+        }
+        task.resume()
+    }
+}

--- a/PopDangSquare/Model/ReviewData.swift
+++ b/PopDangSquare/Model/ReviewData.swift
@@ -1,0 +1,30 @@
+//
+//  ReviewData.swift
+//  PopDangSquare
+//
+//  Created by 민웅킴 on 4/23/24.
+//
+
+import Foundation
+
+struct ReviewData: Hashable {
+    
+    let detailStars: String
+    let detailDate: String
+    let detailReview: String
+}
+
+extension ReviewData {
+    static let reviews: [ReviewData] = [
+        ReviewData(detailStars: "⭐️", detailDate: "240320", detailReview: "살면서 이렇게 재미없는 영화는 처음봤습니다. 정말로 평점주기 아깝네요. 박ㅍ식 이하의 점수를 줘도 아까울지경이에요. 정말 너무합니다. 다시는 이 영화관 오지 않겠습니다. 진짜로요."),
+        ReviewData(detailStars: "⭐️⭐️", detailDate: "240406", detailReview: "최고에여"),
+        ReviewData(detailStars: "⭐️⭐️⭐️", detailDate: "230507", detailReview: "맘에드는 작품입니다. 다음에 한번 더 보러 와야겠어요"),
+        ReviewData(detailStars: "⭐️⭐️⭐️⭐️", detailDate: "220108", detailReview: "내가 살면서 이런 영화 다시 보나 봐라. 진짜로. 근데 재밌음.. 사실 재미있었다. 나만 보고싶어서 평점 이렇게 남겨봅니다. 하하호호 제작진들 놀랬겠죠? 후핫"),
+        ReviewData(detailStars: "⭐️⭐️⭐️⭐️⭐️", detailDate: "230121", detailReview: "감독님 정말 미친거같아요. 예술입니다.."),
+        ReviewData(detailStars: "⭐️⭐️", detailDate: "222222", detailReview: "짱"),
+        ReviewData(detailStars: "⭐️⭐️", detailDate: "210101", detailReview: "이 영화 진짜 재 ...더보기"),
+        ReviewData(detailStars: "⭐️", detailDate: "230403", detailReview: "ㅋㅋ"),
+        ReviewData(detailStars: "⭐️⭐️⭐️", detailDate: "240202", detailReview: "ㅈㅅ"),
+        ReviewData(detailStars: "⭐️⭐️⭐️⭐️", detailDate: "200202", detailReview: "ㅇㅇ")
+    ]
+}

--- a/PopDangSquare/View/DetailHeaderReusableView.swift
+++ b/PopDangSquare/View/DetailHeaderReusableView.swift
@@ -1,0 +1,17 @@
+//
+//  DetailHeaderReusableView.swift
+//  PopDangSquare
+//
+//  Created by 민웅킴 on 4/22/24.
+//
+
+import UIKit
+
+class DetailHeaderReusableView: UICollectionReusableView {
+        
+    @IBOutlet weak var titleLabel: UILabel!
+    
+    func configure(_ title: String) {
+        titleLabel.text = title
+    }
+}

--- a/PopDangSquare/View/DetailReviewCell.swift
+++ b/PopDangSquare/View/DetailReviewCell.swift
@@ -1,0 +1,33 @@
+//
+//  DetailReviewCell.swift
+//  PopDangSquare
+//
+//  Created by 민웅킴 on 4/23/24.
+//
+
+import UIKit
+
+class DetailReviewCell: UICollectionViewCell {
+    
+    static let cellId = "DetailReviewCell"
+    static let className = "DetailReviewCell"
+    
+    @IBOutlet weak var detailReviewView: UIView!
+    @IBOutlet weak var detailStarsLabel: UILabel!
+    @IBOutlet weak var detailDateLabel: UILabel!
+    @IBOutlet weak var detailReviewLabel: UILabel!
+
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        detailReviewView.layer.cornerRadius = 16
+        detailReviewLabel.numberOfLines = 0
+        detailReviewLabel.adjustsFontSizeToFitWidth = true
+    }
+
+    public func configure(_ reviewInfo: ReviewData) {
+        detailStarsLabel.text = reviewInfo.detailStars
+        detailDateLabel.text = reviewInfo.detailDate
+        detailReviewLabel.text = reviewInfo.detailReview
+    }
+}

--- a/PopDangSquare/View/DetailReviewCell.xib
+++ b/PopDangSquare/View/DetailReviewCell.xib
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="DetailReviewCell" customModule="PopDangSquare" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="302" height="147"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="302" height="147"/>
+                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ASX-qJ-NFV">
+                        <rect key="frame" x="31" y="9" width="240" height="128"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0YW-aJ-chK">
+                                <rect key="frame" x="8" y="10" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="plR-Lz-i23">
+                                <rect key="frame" x="190" y="10" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="55e-TY-bEx">
+                                <rect key="frame" x="10" y="54.000000000000007" width="220" height="20.333333333333336"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="0.75294125079999996" green="0.75294119120000003" blue="0.75294119120000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="55e-TY-bEx" secondAttribute="trailing" constant="10" id="0GX-ye-vEu"/>
+                            <constraint firstItem="55e-TY-bEx" firstAttribute="centerY" secondItem="ASX-qJ-NFV" secondAttribute="centerY" id="2F0-0b-yKL"/>
+                            <constraint firstItem="0YW-aJ-chK" firstAttribute="leading" secondItem="ASX-qJ-NFV" secondAttribute="leading" constant="8" id="EjK-Qn-YLX"/>
+                            <constraint firstAttribute="trailing" secondItem="plR-Lz-i23" secondAttribute="trailing" constant="8" id="UAz-qM-k2A"/>
+                            <constraint firstItem="plR-Lz-i23" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="0YW-aJ-chK" secondAttribute="trailing" constant="10" id="Ydy-VA-kjY"/>
+                            <constraint firstItem="plR-Lz-i23" firstAttribute="top" secondItem="ASX-qJ-NFV" secondAttribute="top" constant="10" id="e5z-Ud-6Q4"/>
+                            <constraint firstItem="0YW-aJ-chK" firstAttribute="top" secondItem="ASX-qJ-NFV" secondAttribute="top" constant="10" id="gdb-FM-IUJ"/>
+                            <constraint firstItem="55e-TY-bEx" firstAttribute="centerX" secondItem="ASX-qJ-NFV" secondAttribute="centerX" id="mRe-PJ-nWS"/>
+                            <constraint firstItem="55e-TY-bEx" firstAttribute="leading" secondItem="ASX-qJ-NFV" secondAttribute="leading" constant="10" id="vso-Wd-uB8"/>
+                        </constraints>
+                    </view>
+                </subviews>
+            </view>
+            <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="ASX-qJ-NFV" secondAttribute="trailing" constant="31" id="Clm-yC-Zdc"/>
+                <constraint firstItem="ASX-qJ-NFV" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="9" id="D13-aw-kje"/>
+                <constraint firstAttribute="bottom" secondItem="ASX-qJ-NFV" secondAttribute="bottom" constant="10" id="lJw-9C-IBB"/>
+                <constraint firstItem="ASX-qJ-NFV" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="31" id="sQC-eu-XEs"/>
+            </constraints>
+            <size key="customSize" width="302" height="147"/>
+            <connections>
+                <outlet property="detailDateLabel" destination="plR-Lz-i23" id="C4p-fv-DJ2"/>
+                <outlet property="detailReviewLabel" destination="55e-TY-bEx" id="t8J-br-g7W"/>
+                <outlet property="detailReviewView" destination="ASX-qJ-NFV" id="xfg-oj-YN0"/>
+                <outlet property="detailStarsLabel" destination="0YW-aJ-chK" id="K8M-kj-50C"/>
+            </connections>
+            <point key="canvasLocation" x="235.11450381679387" y="54.577464788732399"/>
+        </collectionViewCell>
+    </objects>
+</document>

--- a/PopDangSquare/View/DetailView.storyboard
+++ b/PopDangSquare/View/DetailView.storyboard
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Detail View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="DetailViewController" id="Y6W-OH-hqX" customClass="DetailViewController" customModule="PopDangSquare" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="gBL-50-XlE">
+                                <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Vxf-Ck-jLQ">
+                                    <size key="itemSize" width="393" height="387"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells/>
+                            </collectionView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="gBL-50-XlE" firstAttribute="centerX" secondItem="vDu-zF-Fre" secondAttribute="centerX" id="42I-Dw-anf"/>
+                            <constraint firstItem="gBL-50-XlE" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="AHb-8k-qit"/>
+                            <constraint firstItem="gBL-50-XlE" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="Arz-pA-BFU"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="gBL-50-XlE" secondAttribute="bottom" id="HSo-JX-zXX"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="gBL-50-XlE" secondAttribute="trailing" id="Hkg-L1-USF"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="detailCollView" destination="gBL-50-XlE" id="mzJ-Vu-4GT"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="138.1679389312977" y="-2.1126760563380285"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/PopDangSquare/View/DetailViewCell.swift
+++ b/PopDangSquare/View/DetailViewCell.swift
@@ -1,0 +1,37 @@
+//
+//  DetailViewCell.swift
+//  PopDangSquare
+//
+//  Created by 민웅킴 on 4/23/24.
+//
+
+import UIKit
+
+class DetailViewCell: UICollectionViewCell {
+    
+    static let cellId = "DetailViewCell"
+    static let className = "DetailViewCell"
+
+    @IBOutlet weak var detailBackImage: UIImageView!
+    @IBOutlet weak var detailPosterImage: UIImageView!
+    @IBOutlet weak var detailMovieLabel: UILabel!
+    @IBOutlet weak var detailMovieENLabel: UILabel!
+    @IBOutlet weak var detailDateLabel: UILabel!
+    @IBOutlet weak var detailGenreLabel: UILabel!
+    @IBOutlet weak var detailStoryTitle: UILabel!
+    @IBOutlet weak var detailStoryLabel: UILabel!
+    
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        detailBackImage.backgroundColor = .red
+        detailPosterImage.backgroundColor = .cyan
+    }
+    
+    public func configure(_ detailInfo: DetailData) {
+        detailMovieLabel.text = detailInfo.movieNm
+        detailMovieENLabel.text = detailInfo.movieNmEn
+        detailDateLabel.text = detailInfo.prdtYear
+    }
+
+}

--- a/PopDangSquare/View/DetailViewCell.xib
+++ b/PopDangSquare/View/DetailViewCell.xib
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" restorationIdentifier="DetailViewCell" reuseIdentifier="DetailViewCell" id="bgD-qa-7i3" userLabel="Detail View Cell" customClass="DetailViewCell" customModule="PopDangSquare" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="393" height="387"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="rar-X8-dvd">
+                <rect key="frame" x="0.0" y="0.0" width="393" height="387"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ada-dj-mdE">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="232.33333333333334"/>
+                        <color key="backgroundColor" red="0.9533130527" green="0.74394315479999995" blue="0.2120856941" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </imageView>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="kq5-5m-xWg">
+                        <rect key="frame" x="27" y="86.000000000000014" width="122" height="176.33333333333337"/>
+                        <color key="backgroundColor" red="0.091979749499999999" green="0.1100719497" blue="0.38009524350000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="176.33000000000001" id="3Gw-5Y-5sD"/>
+                        </constraints>
+                    </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ero-zG-2fN">
+                        <rect key="frame" x="167" y="124" width="185" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EWg-1d-cAP">
+                        <rect key="frame" x="167" y="153" width="185" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WLH-EX-06v">
+                        <rect key="frame" x="167" y="182" width="185" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yfH-nP-1mj">
+                        <rect key="frame" x="27" y="277.33333333333331" width="42" height="20"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Mg-9D-PxJ">
+                        <rect key="frame" x="175" y="241.33333333333334" width="42" height="21.000000000000028"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="96S-ae-VE5">
+                        <rect key="frame" x="166" y="86" width="186" height="30"/>
+                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="25"/>
+                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="EWg-1d-cAP" firstAttribute="top" secondItem="ero-zG-2fN" secondAttribute="bottom" constant="8" id="2FP-Wa-iJU"/>
+                    <constraint firstItem="EWg-1d-cAP" firstAttribute="leading" secondItem="ero-zG-2fN" secondAttribute="leading" id="8WZ-ys-dPf"/>
+                    <constraint firstItem="6Mg-9D-PxJ" firstAttribute="bottom" secondItem="kq5-5m-xWg" secondAttribute="bottom" id="8v7-wi-nEB"/>
+                    <constraint firstItem="ada-dj-mdE" firstAttribute="top" secondItem="rar-X8-dvd" secondAttribute="top" id="9Ia-la-kkG"/>
+                    <constraint firstItem="WLH-EX-06v" firstAttribute="top" secondItem="EWg-1d-cAP" secondAttribute="bottom" constant="8" id="DXU-kn-Gfg"/>
+                    <constraint firstItem="WLH-EX-06v" firstAttribute="leading" secondItem="EWg-1d-cAP" secondAttribute="leading" id="ESt-BU-f3G"/>
+                    <constraint firstAttribute="trailing" secondItem="kq5-5m-xWg" secondAttribute="trailing" constant="244" id="Mbi-QN-NY5"/>
+                    <constraint firstItem="ero-zG-2fN" firstAttribute="top" secondItem="96S-ae-VE5" secondAttribute="bottom" constant="8" id="Uqh-2R-3aI"/>
+                    <constraint firstItem="96S-ae-VE5" firstAttribute="leading" secondItem="kq5-5m-xWg" secondAttribute="trailing" constant="17" id="ZxS-vM-8pf"/>
+                    <constraint firstItem="kq5-5m-xWg" firstAttribute="leading" secondItem="rar-X8-dvd" secondAttribute="leading" constant="27" id="bdy-0w-1tn"/>
+                    <constraint firstItem="96S-ae-VE5" firstAttribute="top" secondItem="kq5-5m-xWg" secondAttribute="top" id="cax-lF-kdf"/>
+                    <constraint firstItem="kq5-5m-xWg" firstAttribute="bottom" secondItem="ada-dj-mdE" secondAttribute="bottom" constant="30" id="mDD-V0-rtU"/>
+                    <constraint firstAttribute="trailing" secondItem="WLH-EX-06v" secondAttribute="trailing" constant="41" id="mjA-yU-mbI"/>
+                    <constraint firstItem="ada-dj-mdE" firstAttribute="leading" secondItem="rar-X8-dvd" secondAttribute="leading" id="o0i-aJ-lQ7"/>
+                    <constraint firstItem="6Mg-9D-PxJ" firstAttribute="leading" secondItem="kq5-5m-xWg" secondAttribute="trailing" constant="26" id="oXO-kl-esT"/>
+                    <constraint firstItem="yfH-nP-1mj" firstAttribute="top" secondItem="kq5-5m-xWg" secondAttribute="bottom" constant="15" id="ol0-Dj-rVh"/>
+                    <constraint firstItem="yfH-nP-1mj" firstAttribute="leading" secondItem="kq5-5m-xWg" secondAttribute="leading" id="pmh-sC-UkS"/>
+                    <constraint firstItem="ada-dj-mdE" firstAttribute="centerX" secondItem="rar-X8-dvd" secondAttribute="centerX" id="qFd-Up-HCl"/>
+                    <constraint firstItem="ero-zG-2fN" firstAttribute="leading" secondItem="96S-ae-VE5" secondAttribute="leading" constant="1" id="txx-MU-RRo"/>
+                    <constraint firstAttribute="trailing" secondItem="ada-dj-mdE" secondAttribute="trailing" id="wgf-Fb-LIJ"/>
+                    <constraint firstItem="ada-dj-mdE" firstAttribute="height" secondItem="rar-X8-dvd" secondAttribute="height" multiplier="0.6" id="xdI-LP-tBZ"/>
+                </constraints>
+            </collectionViewCellContentView>
+            <size key="customSize" width="393" height="387"/>
+            <connections>
+                <outlet property="detailBackImage" destination="ada-dj-mdE" id="c21-6t-she"/>
+                <outlet property="detailDateLabel" destination="EWg-1d-cAP" id="CSJ-yc-E1i"/>
+                <outlet property="detailGenreLabel" destination="WLH-EX-06v" id="iBr-VG-5K0"/>
+                <outlet property="detailMovieENLabel" destination="ero-zG-2fN" id="7JW-QI-ie5"/>
+                <outlet property="detailMovieLabel" destination="96S-ae-VE5" id="TSP-Jw-1MV"/>
+                <outlet property="detailPosterImage" destination="kq5-5m-xWg" id="Tct-Vd-7mP"/>
+                <outlet property="detailStoryLabel" destination="yfH-nP-1mj" id="VmU-Hv-Yy5"/>
+                <outlet property="detailStoryTitle" destination="6Mg-9D-PxJ" id="7V4-Tw-Efc"/>
+            </connections>
+            <point key="canvasLocation" x="139.69465648854961" y="-180.63380281690141"/>
+        </collectionViewCell>
+    </objects>
+</document>


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- #4 

👷 **작업한 내용**
- 디테일뷰 스토리보드에 빈 컬렉션뷰 생성
- 상세페이지 collectionView Xib 두개 연결
- 영화 상세정보, 실관람평 구도 잡기


## 🚨 참고 사항
- 네트워크 매니저 파일 작성중
- 두 셀에 해당하는 더미데이터 모델 생성
- 섹션 관리용 ReusableView파일 생성
- 첫번째 컬렉션뷰셀 xib에는 선택된 영화에 관한 상세정보가 나오는 뷰
- 두번째 컬렉션뷰셀 xib안에는 실관람평 데이터를 불러오는 뷰
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|두 개의 컬렉션 뷰 |
<img width="425" alt="스크린샷 2024-04-24 오후 5 42 38" src="https://github.com/suri0000/PopDangSquare/assets/39073987/f8323a32-ed1b-4866-9c89-30abec4cd221">
|

## 📟 관련 이슈
- Resolved: #4 
